### PR TITLE
Fix greedy `DB/DW string` with `[[:print:]]` class

### DIFF
--- a/src/lib/preprocessor/preprocessor.lalrpop
+++ b/src/lib/preprocessor/preprocessor.lalrpop
@@ -92,7 +92,7 @@ db_directive:() = {
         context.data_counter += n;
     },
     // set string
-    <start:@L> <l:label?> quote_db <q:r#""[[:ascii:]]*""#> <end:@R> =>?{
+    <start:@L> <l:label?> quote_db <q:r#""[[:print:]]*""#> <end:@R> =>?{
         if q.len() > (u16::MAX-10) as usize{ // 10 is arbitrary
             return error!(start,end,format!("Single string can have at most {} characters, overflowing this would set the labels incorrectly, consider splitting string and using set to change location counter",u16::MAX-10));
         }
@@ -141,7 +141,7 @@ dw_directive:() = {
         context.data_counter += 2*n;
     },
     //set string
-    <start:@L> <l:label?> quote_dw <q:r#""[[:ascii:]]*""#> <end:@R> =>?{
+    <start:@L> <l:label?> quote_dw <q:r#""[[:print:]]*""#> <end:@R> =>?{
         if q.len() > ((u16::MAX/2)-10) as usize { // 10 is arbitrary
             return error!(start,end,format!("Single string can have at most {} characters, overflowing this would set the labels incorrectly, consider splitting string and using set to change location counter",(u16::MAX/2)-10));
         }


### PR DESCRIPTION
Hello,

We have the same issue with my students: https://github.com/YJDoc2/8086-Emulator/issues/5#issuecomment-1240457457

I tried [different classes](https://docs.rs/regex/latest/regex/#ascii-character-classes) on https://rustexp.lpil.uk/ and found that  `[[:print:]]`  is "not greedy".

So, the issue can be fixed by using `[[:print:]]` class in `preprocessor.lalrpop` for `DB` and `DW`.

#### Two strings :ok_hand:

```asm
byte01: DB 0x11
string01: DB "123"
string02: DW "456" 
byte02: DB 0x44

start:
print mem :7
MOV AX, 0x1111
MOV BL, OFFSET string01
MOV CL, OFFSET string02
MOV DX, 0x4444
print reg
```
```bash
$ emulator_8086 99-test.asm 
Syntax Error at 10:8 : MOV CL, OFFSET string02 :
Label string02 is not declared.

$ ./8086-Emulator/target/debug/emulator_8086 99-test.asm 
Output of line 7 : print mem :7 :
11	31	32	33	34	35	36	44		
Output of line 12 : print reg :
AX : 0x1111		SP : 0x0000
BX : 0x0001		BP : 0x0000
CX : 0x0004		SI : 0x0000
DX : 0x4444		DI : 0x0000

CS : 0xFFFF		SS : 0x0000
DS : 0x0000		ES : 0x0000
```
#### No regression :ok_hand: (I hope :wink:)

```bash
for p in ./8086-Emulator/examples/*.s
do
    echo $p
    if [ $1 == origin ]
    then
        emulator_8086 $p
    else # patched
        ./8086-Emulator/target/debug/emulator_8086 $p
    fi
done

$ ./all-test.sh origin > o.txt && ./all-test.sh patched > p.txt  && diff o.txt p.txt | wc 
      0       0       0
```


